### PR TITLE
 [OpenAPI] Add endpoint for list of events #179 

### DIFF
--- a/src/AzureOpenAIProxy.ApiApp/AzureOpenAIProxy.ApiApp.csproj
+++ b/src/AzureOpenAIProxy.ApiApp/AzureOpenAIProxy.ApiApp.csproj
@@ -4,7 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>AzureOpenAIProxy.ApiApp</AssemblyName>
     <RootNamespace>AzureOpenAIProxy.ApiApp</RootNamespace>
   </PropertyGroup>

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/EndpointUrls.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/EndpointUrls.cs
@@ -1,4 +1,4 @@
-﻿namespace AzureOpenAIProxy.ApiApp.Endpoints;
+namespace AzureOpenAIProxy.ApiApp.Endpoints;
 
 /// <summary>
 /// This represents the collection of the endpoint URLs.
@@ -14,4 +14,9 @@ public static class EndpointUrls
     /// Declares the chat completions endpoint.
     /// </summary>
     public const string ChatCompletions = "/openai/deployments/{deploymentName}/chat/completions";
+
+    /// <summary>
+    /// Declares the event endpoint.
+    /// </summary>
+    public const string Events = "/events";
 }

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/EventEndpoint.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/EventEndpoint.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using AzureOpenAIProxy.ApiApp.Models;
+
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AzureOpenAIProxy.ApiApp.Endpoints
+{
+    public static class EventEndpoint
+    {
+        public static RouteHandlerBuilder AddEventEndpoint(this WebApplication app)
+        {
+            // TODO: Authorization process with bearer token (JWT) with endpoint filter
+            var rt = app.MapGet(EndpointUrls.Events,
+                (
+                    HttpRequest request
+                ) =>
+                {
+                    // These events are mock for now.
+                    var sampleEvents = new List<EventListEntity>
+                    {
+                        new EventListEntity { EventName = "Opening Hackathon",
+                            EventId = Guid.NewGuid().ToString(),
+                            StartTime = DateTimeOffset.Now,
+                            EndTime = DateTimeOffset.Now.AddDays(1),
+                            IsActive = true,
+                            OrganizerName = "John Doe",
+                            OrganizerEmail = "me@example.com",
+                            TimeZone = TimeZoneInfo.FindSystemTimeZoneById("Asia/Seoul").Id,
+                            Registered = 10,
+                            Resources = new List<EventListEntity.ResourceEntity>
+                            {
+                                new EventListEntity.ResourceEntity { ResourceId = "1", ResourceName = "gpt4o" }
+                            }
+                        }
+                    };
+                    // TODO: Should add 404 logic if the server failed to retrieve data with TypedResult
+                    return TypedResults.Ok(sampleEvents);
+                })
+                // Note: RouteHandlerBuilder does not have ProducesProblem extension method yet, but it will be added on .NET 9
+                // Source: https://github.com/dotnet/aspnetcore/issues/56178
+                .Produces<EventListEntity>(statusCode: StatusCodes.Status200OK, contentType: "application/json")
+                .Produces<ProblemHttpResult>(statusCode: StatusCodes.Status401Unauthorized, contentType: "application/problem+json")
+                .Produces<ProblemHttpResult>(statusCode: StatusCodes.Status404NotFound, contentType: "application/problem+json")
+                .Produces<ProblemHttpResult>(statusCode: StatusCodes.Status500InternalServerError, contentType: "application/problem+json")
+                .WithTags("events")
+                .WithName("GetEvents")
+                .WithOpenApi(operations =>
+                {
+                    operations.Description = "Show all events in Azure OpenAI Proxy services.";
+                    operations.Summary = "Get all events";
+                    return operations;
+                });
+
+            return rt;
+        }
+    }
+}

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/EventEndpoint.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/EventEndpoint.cs
@@ -6,11 +6,19 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace AzureOpenAIProxy.ApiApp.Endpoints
 {
+    /// <summary>
+    /// Defines an endpoint for events
+    /// </summary>
     public static class EventEndpoint
     {
+        /// <summary>
+        /// Adds EventEndpoint to WebApplication.
+        /// </summary>
+        /// <param name="app"></param>
+        /// <returns></returns>
         public static RouteHandlerBuilder AddEventEndpoint(this WebApplication app)
         {
-            // TODO: Authorization process with bearer token (JWT) with endpoint filter
+            // TODO: Parameter validation
             var rt = app.MapGet(EndpointUrls.Events,
                 (
                     HttpRequest request
@@ -36,6 +44,7 @@ namespace AzureOpenAIProxy.ApiApp.Endpoints
                     };
                     // TODO: Should add 404 logic if the server failed to retrieve data with TypedResult
                     return TypedResults.Ok(sampleEvents);
+                    // return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
                 })
                 // Note: RouteHandlerBuilder does not have ProducesProblem extension method yet, but it will be added on .NET 9
                 // Source: https://github.com/dotnet/aspnetcore/issues/56178

--- a/src/AzureOpenAIProxy.ApiApp/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using AzureOpenAIProxy.ApiApp.Builders;
+using System.Reflection;
+
+using AzureOpenAIProxy.ApiApp.Builders;
 using AzureOpenAIProxy.ApiApp.Configurations;
 using AzureOpenAIProxy.ApiApp.Filters;
 using AzureOpenAIProxy.ApiApp.Services;
@@ -68,6 +70,7 @@ public static class ServiceCollectionExtensions
                     Url = new Uri("https://aka.ms/aoai-proxy.net")
                 },
             };
+            options.IncludeXmlComments(Assembly.GetExecutingAssembly());
             options.SwaggerDoc(Constants.Version, info);
 
             options.AddSecurityDefinition(

--- a/src/AzureOpenAIProxy.ApiApp/Models/EventListEntity.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Models/EventListEntity.cs
@@ -12,13 +12,13 @@ public class EventListEntity
     /// Event Id
     /// </summary>
     [JsonPropertyName("eventId")]
-    public required string EventId { get; set; }
+    public required string? EventId { get; set; }
 
     /// <summary>
     /// Event name
     /// </summary>
     [JsonPropertyName("eventName")]
-    public required string EventName { get; set; }
+    public required string? EventName { get; set; }
 
     /// <summary>
     ///  Event start time
@@ -42,20 +42,20 @@ public class EventListEntity
     /// Organizer's name
     /// </summary>
     [JsonPropertyName("organizerName")]
-    public required string OrganizerName { get; set; }
+    public required string? OrganizerName { get; set; }
 
     /// <summary>
     /// Organizer's email address.
     /// </summary>
     [EmailAddress]
     [JsonPropertyName("OrganizerEmail")]
-    public required string OrganizerEmail { get; set; }
+    public required string? OrganizerEmail { get; set; }
 
     /// <summary>
     /// The number of registered users
     /// </summary>
     [JsonPropertyName("registered")]
-    public required int Registered { get; set; }
+    public required int? Registered { get; set; }
 
     /// <summary>
     /// List of resources that the organizer deploys
@@ -67,7 +67,7 @@ public class EventListEntity
     /// Shows whether the event is active or not
     /// </summary>
     [JsonPropertyName("isActive")]
-    public required bool IsActive { get; set; }
+    public required bool? IsActive { get; set; }
 
     /// <summary>
     ///  Define the list entity of Resources
@@ -78,12 +78,12 @@ public class EventListEntity
         /// Resource's Id
         /// </summary>
         [JsonPropertyName("id")]
-        public required string ResourceId {get; set; }
+        public required string? ResourceId {get; set; }
 
         /// <summary>
         /// Resource's name. e.g. gpt4o
         /// </summary>
         [JsonPropertyName("name")]
-        public required string ResourceName {get; set; }
+        public required string? ResourceName {get; set; }
     }
 }

--- a/src/AzureOpenAIProxy.ApiApp/Models/EventListEntity.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Models/EventListEntity.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 using AzureOpenAIProxy.ApiApp.Models;
 
 /// <summary>
-/// Data transfer model for showing all events 
+/// Data transfer model for showing all events
 /// </summary>
 public class EventListEntity
 {
@@ -36,7 +36,7 @@ public class EventListEntity
     /// Event's time zone. It could be serialized to string
     /// </summary>
     [JsonPropertyName("tz")]
-    public required TimeZoneInfo? TimeZone { get; set; }
+    public required string? TimeZone { get; set; }
 
     /// <summary>
     /// Organizer's name
@@ -61,7 +61,7 @@ public class EventListEntity
     /// List of resources that the organizer deploys
     /// </summary>
     [JsonPropertyName("resources")]
-    public required virtual IList<ResourceEntity> Resources { get; set; }
+    public virtual IEnumerable<ResourceEntity>? Resources { get; set; }
 
     /// <summary>
     /// Shows whether the event is active or not

--- a/src/AzureOpenAIProxy.ApiApp/Models/EventListEntity.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Models/EventListEntity.cs
@@ -1,0 +1,89 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+using AzureOpenAIProxy.ApiApp.Models;
+
+/// <summary>
+/// Data transfer model for showing all events 
+/// </summary>
+public class EventListEntity
+{
+    /// <summary>
+    /// Event Id
+    /// </summary>
+    [JsonPropertyName("eventId")]
+    public required string EventId { get; set; }
+
+    /// <summary>
+    /// Event name
+    /// </summary>
+    [JsonPropertyName("eventName")]
+    public required string EventName { get; set; }
+
+    /// <summary>
+    ///  Event start time
+    /// </summary>
+    [JsonPropertyName("startTime")]
+    public required DateTimeOffset? StartTime { get; set; }
+
+    /// <summary>
+    /// Event end time
+    /// </summary>
+    [JsonPropertyName("endTime")]
+    public required DateTimeOffset? EndTime { get; set; }
+
+    /// <summary>
+    /// Event's time zone. It could be serialized to string
+    /// </summary>
+    [JsonPropertyName("tz")]
+    public required TimeZoneInfo? TimeZone { get; set; }
+
+    /// <summary>
+    /// Organizer's name
+    /// </summary>
+    [JsonPropertyName("organizerName")]
+    public required string OrganizerName { get; set; }
+
+    /// <summary>
+    /// Organizer's email address.
+    /// </summary>
+    [EmailAddress]
+    [JsonPropertyName("OrganizerEmail")]
+    public required string OrganizerEmail { get; set; }
+
+    /// <summary>
+    /// The number of registered users
+    /// </summary>
+    [JsonPropertyName("registered")]
+    public required int Registered { get; set; }
+
+    /// <summary>
+    /// List of resources that the organizer deploys
+    /// </summary>
+    [JsonPropertyName("resources")]
+    public required virtual IList<ResourceEntity> Resources { get; set; }
+
+    /// <summary>
+    /// Shows whether the event is active or not
+    /// </summary>
+    [JsonPropertyName("isActive")]
+    public required bool IsActive { get; set; }
+
+    /// <summary>
+    ///  Define the list entity of Resources
+    /// </summary>
+    public class ResourceEntity
+    {
+        /// <summary>
+        /// Resource's Id
+        /// </summary>
+        [JsonPropertyName("id")]
+        public required string ResourceId {get; set; }
+
+        /// <summary>
+        /// Resource's name. e.g. gpt4o
+        /// </summary>
+        [JsonPropertyName("name")]
+        public required string ResourceName {get; set; }
+    }
+}

--- a/src/AzureOpenAIProxy.ApiApp/Program.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Program.cs
@@ -35,5 +35,6 @@ app.UseHttpsRedirection();
 
 app.AddWeatherForecast();
 app.AddChatCompletions();
+app.AddEventEndpoint();
 
 await app.RunAsync();

--- a/src/AzureOpenAIProxy.ApiApp/Program.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Program.cs
@@ -1,5 +1,9 @@
+using System.Reflection;
+
 using AzureOpenAIProxy.ApiApp.Endpoints;
 using AzureOpenAIProxy.ApiApp.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -23,6 +27,7 @@ app.UseRouting();
 // Configure the HTTP request pipeline.
 // Use Swagger UI
 app.UseSwaggerUI(basePath);
+app.UseSwagger();
 
 // Enable buffering
 app.Use(async (context, next) =>


### PR DESCRIPTION
## Description 
* #179
 /events GET handler와, handler에서 사용할 Data Transfer Object 모델인 ```EventListEntity```, 해당 핸들러가 있는 ```EventEndpoint```를 추가하였습니다.

현재 ```GET``` handler는 샘플의 ```EventListEntity```를 생성해 반환하는 방식으로 구현되어 있습니다.

## Features on this PR

이벤트를 보여주기 위해 필요한 정보를 담는 클래스 두 개를 새로 정의했습니다.

### EventListEntity

```json
      "EventListEntity": {
        "required": [
          "endTime",
          "eventId",
          "eventName",
          "isActive",
          "OrganizerEmail",
          "organizerName",
          "registered",
          "startTime",
          "tz"
        ],
        "type": "object",
        "properties": {
          "eventId": {
            "type": "string",
            "description": "Event Id",
            "nullable": true
          },
          "eventName": {
            "type": "string",
            "description": "Event name",
            "nullable": true
          },
          "startTime": {
            "type": "string",
            "description": "Event start time",
            "format": "date-time",
            "nullable": true
          },
          "endTime": {
            "type": "string",
            "description": "Event end time",
            "format": "date-time",
            "nullable": true
          },
          "tz": {
            "type": "string",
            "description": "Event's time zone. It could be serialized to string",
            "nullable": true
          },
          "organizerName": {
            "type": "string",
            "description": "Organizer's name",
            "nullable": true
          },
          "OrganizerEmail": {
            "type": "string",
            "description": "Organizer's email address.",
            "format": "email",
            "nullable": true
          },
          "registered": {
            "type": "integer",
            "description": "The number of registered users",
            "format": "int32",
            "nullable": true
          },
          "resources": {
            "type": "array",
            "items": {
              "$ref": "#/components/schemas/ResourceEntity"
            },
            "description": "List of resources that the organizer deploys",
            "nullable": true
          },
          "isActive": {
            "type": "boolean",
            "description": "Shows whether the event is active or not",
            "nullable": true
          }
        },
        "additionalProperties": false,
        "description": "Data transfer model for showing all events"
      },
```
해당 클래스는 내부에 리소스 정보를 담기 위해 ResourceEntity라는 서브 클래스 정의를 갖고 있습니다.

### ResourceEntity

```json
"ResourceEntity": {
        "required": [
          "id",
          "name"
        ],
        "type": "object",
        "properties": {
          "id": {
            "type": "string",
            "description": "Resource's Id",
            "nullable": true
          },
          "name": {
            "type": "string",
            "description": "Resource's name. e.g. gpt4o",
            "nullable": true
          }
        },
        "additionalProperties": false,
        "description": "Define the list entity of Resources"
      },
```
Azure 쪽에서는 리소스(예: gpt4o)를 표시하고 있었기 때문에 추가하였습니다. 이 클래스에서는 리소스 ID와 이름만 들어 있습니다. 리소스에 대한 자세한 정보를 담는 클래스는 별도로 정의될 것 같습니다.

### Endpoint

이벤트 목록을 반환하는 GET 메소드를 ```MapGet```을 통해 ```/events``` 경로 하에 정의하였으며, 해당 메소드를 갖고 있는 endpoint를 ```RouteHandlerBuilder```를 사용하여 ```EventEndpoint```로 정의하였습니다.

```json
"paths": {
    "/events": {
      "get": {
        "tags": [
          "events"
        ],
        "summary": "Get all events",
        "description": "Show all events in Azure OpenAI Proxy services.",
        "operationId": "GetEvents",
        "responses": {
          "200": {
            "description": "OK",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/EventListEntity"
                }
              }
            }
          },
          "401": {
            "description": "Unauthorized",
            "content": {
              "application/problem+json": {
                "schema": {
                  "$ref": "#/components/schemas/ProblemHttpResult"
                }
              }
            }
          },
          "404": {
            "description": "Not Found",
            "content": {
              "application/problem+json": {
                "schema": {
                  "$ref": "#/components/schemas/ProblemHttpResult"
                }
              }
            }
          },
          "500": {
            "description": "Internal Server Error",
            "content": {
              "application/problem+json": {
                "schema": {
                  "$ref": "#/components/schemas/ProblemHttpResult"
                }
              }
            }
          }
        }
      }
    },
```

아울러, 페이로드를 정의해야 했으나 현재 구현에서는 샘플 객체를 반환하는 방식으로만 구현했고, Authorization 관련 구현이 없어 따로 정의하지는 않았습니다.

```events```는 TypedResults를 이용해 정상적으로는 200 OK를 반환하며, Authorization 없는 접근의 경우 401번, 찾을 수 없었던 경우면 404번, 서버에 문제가 생긴 경우 500번을 반환하게 정했습니다.

해당 endpoint에 관련된 테스트도 추가하겠습니다.

감사합니다.